### PR TITLE
add OK.byTime exclusion information

### DIFF
--- a/getExclusions.m
+++ b/getExclusions.m
@@ -8,7 +8,7 @@
 %                   at least one type?
 % OK.DSI{ia}(nTypes, nUnits(ia)): what is the diresction selectivity?
 
-function [OK] = getExclusions(tcs)
+function [OK] = getExclusions(tcs, varargin)
 
 % figure out some data-related parameters
 types = fieldnames(tcs.Move);                   % what types
@@ -23,8 +23,17 @@ nUnits = tmp(:, 1);                             % how many units per area
 %   in at least one of the 12 directions
 
 % parameters 
-pThresh = 0.05;
-trialStep = 10; %test 10 trials at a time for visual responsiveness (move > blank)
+if nargin < 3
+    pThresh = 0.05;
+    if nargin < 2
+        trialStep = 10;
+    else 
+        trialStep = varargin{2}; 
+    end
+else 
+    pThresh = varargin{3};
+end
+
 
 for ia = 1:nAreas   
 for it = 1:nTypes

--- a/getExclusions.m
+++ b/getExclusions.m
@@ -1,7 +1,6 @@
 % getExclusionCriteria
 function [OK] = getExclusions(tcs)
 
-
 % figure out some data-related parameters
 types = fieldnames(tcs.Move);                   % what types
 [nAreas, nDirs] = size(tcs.Move.(types{1}));    % how many areas + dirs
@@ -11,38 +10,38 @@ tmp = cellfun(@(x) size(x, 1), ...
                 tcs.Move.(types{1}));
 nUnits = tmp(:, 1);                             % how many units per area                    
 
-% preallocate
-for ia = 1:nAreas
-   OK.isVisual{ia} = zeros(nTypes, nUnits(ia));   
-   OK.anyVisual{ia} = zeros(1, nUnits(ia));   
-   OK.DSI{ia} = zeros(nTypes, nUnits(ia));
-end
-
-
 % Must respond more to move than blank throughout experiment
 %   in at least one of the 12 directions
 
 % parameters 
 pThresh = 0.05;
-nBins = 4;
-
+trialStep = 10; %test 10 trials at a time for visual responsiveness (move > blank)
 
 for ia = 1:nAreas   
 for it = 1:nTypes
-    overThresh = zeros(nUnits(ia), nDirs);
+    p = nan(nUnits(ia), nBins, nDirs);
 for id = 1:nDirs
     tmpMV = tcs.Move.(types{it}){ia,id};
     tmpBK = tcs.Blank.(types{it}){ia,id};
     
     nTrials = size(tmpBK, 2);
-    trialStep = nTrials/nBins;
+    nBins = ceil(nTrials/trialStep);
     binStarts = 1:trialStep:nTrials;
+    
+    %preallocate
+    if it == 1 && id == 1
+        OK.byTime{ia} = zeros(nTypes, nUnits(ia), nTrials);
+        OK.isVisual{ia} = zeros(nTypes, nUnits(ia));   
+        OK.anyVisual{ia} = zeros(1, nUnits(ia));   
+        OK.DSI{ia} = zeros(nTypes, nUnits(ia));
+    end
+    
     for iu = 1:nUnits(ia)
-        p = zeros(1, nBins);
         for ib = 1:nBins
             trialRange = binStarts(ib):binStarts(ib)+trialStep-1;
-            p(ib) = kruskalwallis([tmpBK(iu,trialRange)' ...
-                                   tmpMV(iu,trialRange)'], [], 'off');
+            trialRange = trialRange(trialRange <= length(tmpBK)); %last bin may have fewer trials
+            p(iu, ib, id) = ranksum(tmpBK(iu,trialRange), ...
+                                    tmpMV(iu,trialRange), 'tail', 'left');
         end
         % if all bins are significantly modulated
         if prod(p < pThresh) ~= 0 
@@ -50,10 +49,13 @@ for id = 1:nDirs
         end
     end
 end
+    h = p < pThresh; % check p-value against alpha
+    hAnyDir = sum(h, 3) > 0;
+    OK.byTime{ia}(it, :, :) = repelem(hAnyDir, 1, trialStep);
 end
     OK.anyVisual{ia} = sum(OK.isVisual{ia}) > 0;
 end
-    
+   
 % DSI Calculation
 
 for ia = 1:nAreas  

--- a/getExclusions.m
+++ b/getExclusions.m
@@ -55,7 +55,7 @@ for id = 1:nDirs
                                     tmpMV(iu,trialRange), 'tail', 'left');
         end
         % if all bins are significantly modulated
-        if all(p < pThresh)
+        if all(p(iu, :, :) < pThresh)
             OK.isVisual{ia}(it, iu) = 1;
         end
     end


### PR DESCRIPTION
The `OK.byTime` output of `getExclusions.m` now meets the requirement of #4 , I think.

The below image shows an example of the diagnostic information. I decided not to limit how to use it (For example, by committing to a certain level of not-cherrypicking trial blocks by allowing only pre- and post-isolation exclusions). Instead, `OK.byTime` contains a trial-by-trial type-by-type 1/0 indication of whether a trial was in a visually responsive block. Note that a unit got the OK if it was significant in ANY direction. The structure of `OK.byTime` is a matrix of `nTypes x nUnits x nTrials`.  

![image](https://user-images.githubusercontent.com/27422908/167341473-c0c69509-1d37-43b7-b8b6-ad7b327d85c9.png)

